### PR TITLE
Feature/gws 529 stroke thickness

### DIFF
--- a/ios/PTSignaturesManager+Swizzling.h
+++ b/ios/PTSignaturesManager+Swizzling.h
@@ -1,0 +1,14 @@
+//
+//  NSObject+PTSignatureView.h
+//  RNPdftron
+//
+//  Created by Erick Barbosa on 9/5/23.
+//
+
+#import <UIKit/UIKit.h>
+
+#import <Tools/PTSignaturesManager.h>
+#import <Foundation/Foundation.h>
+
+@interface PTSignaturesManager (Swizzling)
+@end

--- a/ios/PTSignaturesManager+Swizzling.m
+++ b/ios/PTSignaturesManager+Swizzling.m
@@ -1,0 +1,34 @@
+#import "PTSignaturesManager+Swizzling.h"
+#import <objc/runtime.h>
+
+@implementation PTSignaturesManager (Swizzling)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = [self class];
+        
+        SEL originalSelector = @selector(createSignature:withStrokeColor:withStrokeThickness:withinRect:saveSignature:);
+        SEL swizzledSelector = @selector(swizzled_createSignature:withStrokeColor:withStrokeThickness:withinRect:saveSignature:);
+        
+        Method originalMethod = class_getInstanceMethod(class, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
+        
+        if (originalMethod && swizzledMethod) {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        } else {
+            NSLog(@"Method swizzling failed. Methods not found.");
+        }
+    });
+}
+
+// The swizzled method
+- (PTPDFDoc *)swizzled_createSignature:(NSMutableArray *)points withStrokeColor:(UIColor *)strokeColor withStrokeThickness:(CGFloat)thickness withinRect:(CGRect)rect saveSignature:(BOOL)saveSignature {
+    
+    // Your custom logic here
+    
+    // Call the original method (which is now `swizzled_createSignature:` because we've exchanged their implementations)
+    return [self swizzled_createSignature:points withStrokeColor:strokeColor withStrokeThickness:15.0 withinRect:rect saveSignature:saveSignature];
+}
+
+@end

--- a/ios/PTSignaturesManager+Swizzling.m
+++ b/ios/PTSignaturesManager+Swizzling.m
@@ -23,10 +23,7 @@
 }
 
 // The swizzled method
-- (PTPDFDoc *)swizzled_createSignature:(NSMutableArray *)points withStrokeColor:(UIColor *)strokeColor withStrokeThickness:(CGFloat)thickness withinRect:(CGRect)rect saveSignature:(BOOL)saveSignature {
-    
-    // Your custom logic here
-    
+- (PTPDFDoc *)swizzled_createSignature:(NSMutableArray *)points withStrokeColor:(UIColor *)strokeColor withStrokeThickness:(CGFloat)thickness withinRect:(CGRect)rect saveSignature:(BOOL)saveSignature {    
     // Call the original method (which is now `swizzled_createSignature:` because we've exchanged their implementations)
     return [self swizzled_createSignature:points withStrokeColor:strokeColor withStrokeThickness:15.0 withinRect:rect saveSignature:saveSignature];
 }

--- a/ios/RNPdftron.xcodeproj/project.pbxproj
+++ b/ios/RNPdftron.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		CE0885F920E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0885F820E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m */; };
 		D30BB17922EFA8D000D90D24 /* RNTPTDocumentViewModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D30BB17822EFA8D000D90D24 /* RNTPTDocumentViewModule.m */; };
 		D9430A482AA73CC200767E1D /* UIViewController+Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = D9430A472AA73CC200767E1D /* UIViewController+Swizzling.m */; };
+		D9FE7C232AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = D9FE7C222AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -44,6 +45,8 @@
 		D30BB17822EFA8D000D90D24 /* RNTPTDocumentViewModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTPTDocumentViewModule.m; sourceTree = "<group>"; };
 		D9430A462AA73CC200767E1D /* UIViewController+Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Swizzling.h"; sourceTree = "<group>"; };
 		D9430A472AA73CC200767E1D /* UIViewController+Swizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Swizzling.m"; sourceTree = "<group>"; };
+		D9FE7C212AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PTSignaturesManager+Swizzling.h"; sourceTree = "<group>"; };
+		D9FE7C222AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PTSignaturesManager+Swizzling.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +77,8 @@
 				CE0885F820E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m */,
 				CE0885F420E2CAB100AB7A9B /* RNTPTPDFViewCtrl.h */,
 				CE0885F520E2CAB100AB7A9B /* RNTPTPDFViewCtrl.m */,
+				D9FE7C212AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.h */,
+				D9FE7C222AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.m */,
 				CE0885F120E2CA1300AB7A9B /* RNTPTDocumentViewManager.h */,
 				CE0885F220E2CA1300AB7A9B /* RNTPTDocumentViewManager.m */,
 				CE0885EE20E2C9F400AB7A9B /* RNTPTDocumentView.h */,
@@ -145,6 +150,7 @@
 			files = (
 				D30BB17922EFA8D000D90D24 /* RNTPTDocumentViewModule.m in Sources */,
 				CE0885F020E2C9F400AB7A9B /* RNTPTDocumentView.m in Sources */,
+				D9FE7C232AA7B5E200C0B6CE /* PTSignaturesManager+Swizzling.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNPdftron.m in Sources */,
 				CE0885F320E2CA1300AB7A9B /* RNTPTDocumentViewManager.m in Sources */,
 				CE0885F920E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m in Sources */,

--- a/ios/RNPdftron.xcodeproj/project.pbxproj
+++ b/ios/RNPdftron.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		CE0885F620E2CAB100AB7A9B /* RNTPTPDFViewCtrl.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0885F520E2CAB100AB7A9B /* RNTPTPDFViewCtrl.m */; };
 		CE0885F920E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CE0885F820E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m */; };
 		D30BB17922EFA8D000D90D24 /* RNTPTDocumentViewModule.m in Sources */ = {isa = PBXBuildFile; fileRef = D30BB17822EFA8D000D90D24 /* RNTPTDocumentViewModule.m */; };
+		D9430A482AA73CC200767E1D /* UIViewController+Swizzling.m in Sources */ = {isa = PBXBuildFile; fileRef = D9430A472AA73CC200767E1D /* UIViewController+Swizzling.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -41,6 +42,8 @@
 		CE0885F820E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNTPTPDFViewCtrlManager.m; sourceTree = "<group>"; };
 		D30BB17722EFA8D000D90D24 /* RNTPTDocumentViewModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNTPTDocumentViewModule.h; sourceTree = "<group>"; };
 		D30BB17822EFA8D000D90D24 /* RNTPTDocumentViewModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNTPTDocumentViewModule.m; sourceTree = "<group>"; };
+		D9430A462AA73CC200767E1D /* UIViewController+Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Swizzling.h"; sourceTree = "<group>"; };
+		D9430A472AA73CC200767E1D /* UIViewController+Swizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Swizzling.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +68,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				D9430A462AA73CC200767E1D /* UIViewController+Swizzling.h */,
+				D9430A472AA73CC200767E1D /* UIViewController+Swizzling.m */,
 				CE0885F720E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.h */,
 				CE0885F820E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m */,
 				CE0885F420E2CAB100AB7A9B /* RNTPTPDFViewCtrl.h */,
@@ -143,6 +148,7 @@
 				B3E7B58A1CC2AC0600A0062D /* RNPdftron.m in Sources */,
 				CE0885F320E2CA1300AB7A9B /* RNTPTDocumentViewManager.m in Sources */,
 				CE0885F920E2CACB00AB7A9B /* RNTPTPDFViewCtrlManager.m in Sources */,
+				D9430A482AA73CC200767E1D /* UIViewController+Swizzling.m in Sources */,
 				CE0885F620E2CAB100AB7A9B /* RNTPTPDFViewCtrl.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/UIViewController+Swizzling.h
+++ b/ios/UIViewController+Swizzling.h
@@ -1,0 +1,16 @@
+//
+//  NSObject+Swizzling.h
+//  RNPdftron
+//
+//  Created by Erick Barbosa on 9/4/23.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIViewController (Swizzling)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/UIViewController+Swizzling.m
+++ b/ios/UIViewController+Swizzling.m
@@ -1,0 +1,51 @@
+//
+//  UIViewController+Swizzling.m
+//  RNPdftron
+//
+//  Created by Erick Barbosa on 9/4/23.
+//
+
+#import "UIViewController+Swizzling.h"
+#import <objc/runtime.h>
+#import <Tools/PTFloatingSigViewController.h>
+
+@implementation UIViewController (Swizzling)
+
++ (void)load {
+    // Ensures that swizzling is performed only once
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        // Get class references
+        Class baseClass = [UIViewController class];
+        Class targetClass = [PTFloatingSigViewController class];
+
+        // Define method selectors
+        SEL originalSelector = @selector(viewWillAppear:);
+        SEL swizzledSelector = @selector(swizzled_viewWillAppear:);
+
+        // Obtain method references
+        Method originalMethod = class_getInstanceMethod(targetClass, originalSelector);
+        Method swizzledMethod = class_getInstanceMethod(baseClass, swizzledSelector);
+
+        // Safety check before method swizzling
+        if (originalMethod && swizzledMethod) {
+            method_exchangeImplementations(originalMethod, swizzledMethod);
+        } else {
+            NSLog(@"Method swizzling failed. Methods not found.");
+        }
+    });
+}
+
+- (void)swizzled_viewWillAppear:(BOOL)animated {
+    // Call the original implementation (since we've exchanged implementations)
+    [self swizzled_viewWillAppear:animated];
+    
+    // Perform type check before casting and applying specific logic
+    if ([self isKindOfClass:[PTFloatingSigViewController class]]) {
+        PTFloatingSigViewController *sigViewController = (PTFloatingSigViewController *)self;
+
+        [sigViewController.digSigView setStrokeThickness:4.0];
+    }
+}
+
+@end


### PR DESCRIPTION
Title: Add Method Swizzling for PTSignaturesManager's createSignature Method
Description:
This pull request adds method swizzling to the createSignature:withStrokeColor:withStrokeThickness:withinRect:saveSignature: method in the PTSignaturesManager class. This will allow us to inject custom logic into this method while still retaining the original functionality.

Changes:
Created a new Objective-C category, PTSignaturesManager+Swizzling.
Added the swizzling logic in the +load method.
Introduced a swizzled version of the createSignature:withStrokeColor:withStrokeThickness:withinRect:saveSignature: method that calls the original implementation.